### PR TITLE
test: add Expo Jest config

### DIFF
--- a/src/jest.config.js
+++ b/src/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'jest-expo',
+  testMatch: ['<rootDir>/engine/**/__tests__/**/*.test.ts'],
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|expo-.*|@unimodules/.*|unimodules-.*|sentry-expo|native-base|react-native-svg)/)',
+  ],
+};


### PR DESCRIPTION
Adds the missing src/jest.config.js so the existing root npm test script can run the deterministic engine tests.\n\nVerified on zyra-mini:\n- npm run typecheck\n- npm --prefix web run typecheck\n- npm --prefix web run build\n- npm test -- --runInBand