### PR TITLE
chore(.gitignore, docs): SSH persistent key setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ playground/*
 *.cache
 .superdesign
 
+# SSH keys
+.ssh/
+
 # Source media copied into src/assets/media for Expo bundling.
 /A_dark_cinematic_cyberpunk_int_Kling_30__25449.mp4
 /photo_2026-04-17_09-03-00.jpg

--- a/Collaboration_Protocol.md
+++ b/Collaboration_Protocol.md
@@ -13,6 +13,18 @@
 
 ## Information flow
 
+<!-- SSH Persistent Key Setup -->
+
+### SSH Persistent Key Setup
+
+- Run `scripts/setup-ssh-zyra-mini.sh` on your local machine to generate an Ed25519 SSH key (if not present) and install it on the `zyra-mini` node.
+- The script uses `ssh-copy-id` when available, falling back to a manual `ssh` command.
+- After successful execution, you should be able to run `ssh zyra-mini` without a password.
+- The generated private key is stored at `~/.ssh/id_ed25519` and is **not** committed to the repository (the `.ssh/` directory is now ignored via `.gitignore`).
+- Documentation for this process is kept in this `Collaboration_Protocol.md` under the **SSH Persistent Key Setup** section.
+
+## Information flow
+
 ```
          ┌──────────────────────────────┐
          │   Ghost + Zoro (humans)      │


### PR DESCRIPTION
## Summary\nAdd .ssh ignore and document SSH persistent key setup for zyra-mini.\n\n## Scope\n- Update .gitignore to ignore .ssh directory.\n- Add SSH setup instructions to Collaboration_Protocol.md.\n\n## Test Plan\n- Verify  shows only intended files.\n- Run [setup‑ssh] Existing SSH key found.
[setup‑ssh] Using ssh-copy-id to install public key on zyra-mini manually; ensure it generates key and reports success (manual host resolution may need verification).\n\n## Linked Task\n- zara-p0-001