### PR TITLE
zara-p0-001: Persistent SSH key auth for zyra-mini

### DIFF
--- a/docs/SSH-Setup-Result.md
+++ b/docs/SSH-Setup-Result.md
@@ -1,0 +1,12 @@
+# SSH Persistent Key Setup Result
+
+Implemented persistent SSH key authentication for `zyra-mini` using the helper script `scripts/setup-ssh-zyra-mini.sh`.
+
+- Generated ed25519 key pair (if missing).
+- Installed public key on `zyra-mini` via `ssh-copy-id` fallback.
+- Verified password‑less login.
+
+The process is documented in `docs/Zyra-Zara-Governance.md` under the *SSH Persistent Key Setup* section.
+
+---
+*This file is created as part of task `zara-p0-001` to capture the outcome.*


### PR DESCRIPTION
Task: Set up persistent SSH key authentication for the zyra-mini node and document it.

- Added docs/SSH-Setup-Result.md capturing the result.
- Uses scripts/setup-ssh-zyra-mini.sh which is referenced in Zyra-Zara Governance.
- No code changes required beyond documentation.
