### PR TITLE
feat: GLB compression script for zara-p0-002

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test": "jest --config=src/jest.config.js",
     "test:watch": "jest --watch --config=src/jest.config.js",
     "watch:glb": "node scripts/watch-glb-assets.js",
+    "compress-glb": "node scripts/compress-glb.js",
 
     "verify:phase1": "npm run typecheck && npm run lint && npm run test && echo '\\n[ok] Phase 1 verification passed.'"
   },

--- a/scripts/compress-glb.js
+++ b/scripts/compress-glb.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * Simple GLB compression script using gltf-pipeline.
+ * Usage: npm run compress-glb -- <relative-path-to-GLB>
+ * Example: npm run compress-glb -- web/public/GLB_Assets/Avatar_zara.glb
+ */
+const path = require('path');
+const fs = require('fs');
+const { processGltf } = require('gltf-pipeline');
+
+if (process.argv.length < 3) {
+  console.error('Usage: compress-glb <path-to-glb>');
+  process.exit(1);
+}
+
+const inputRel = process.argv[2];
+const inputPath = path.resolve(process.cwd(), inputRel);
+if (!fs.existsSync(inputPath)) {
+  console.error('[compress-glb] Input file does not exist:', inputPath);
+  process.exit(1);
+}
+
+const outputPath = inputPath.replace(/\.glb$/i, '.compressed.glb');
+
+(async () => {
+  try {
+    const data = fs.readFileSync(inputPath);
+    const options = {
+      dracoOptions: { compressionLevel: 10 },
+      // Additional options can be added for LOD generation later.
+    };
+    const result = await processGltf(data, options);
+    fs.writeFileSync(outputPath, Buffer.from(result.glb));
+    console.log('[compress-glb] Compressed GLB written to', outputPath);
+  } catch (e) {
+    console.error('[compress-glb] Error:', e);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
Add a node script  using gltf-pipeline to compress GLB assets and an npm script entry. This supports the task  to compress/LOD heavy GLBs before mobile reuse.

## Scope
- New script in 
- Updated  with  npm script

## Test Plan
- Run 
> cybertrader-age-of-pantheon-dev-lab@0.1.0-phase0 compress-glb
> node scripts/compress-glb.js web/public/GLB_Assets/Avatar_zara.glb and verify a  file is generated.
- Ensure existing build and typecheck still pass.

## Linked Task
-  (Compress/LOD heavy GLBs)
